### PR TITLE
New option to enable balancing of [] and {} regardless of language

### DIFF
--- a/doc/paredit.txt
+++ b/doc/paredit.txt
@@ -22,7 +22,7 @@ added or deleted, they are entered or removed in pairs.
 The function takes care of strings and comments, so no parenthesis and square
 bracket balancing is performed inside a string or comment.
 Please note that [] and {} pairs are not balanced for Lisp filetypes, only
-for Clojure and Scheme.
+for Clojure and Scheme by default.
 
 The idea is taken from the paredit mode of Emacs, but not all paredit.el
 editing functions are implemented or behave exactly the same way as they do
@@ -378,6 +378,9 @@ PAREDIT OPTIONS                                               *paredit-options*
 
 |g:paredit_electric_return|  If nonzero, electric return feature is enabled.
 
+|g:paredit_full_balancing|   If nonzero, [] and {} are also balanced,
+                             regardless of the language.
+
 |g:paredit_smartjump|        If nonzero, '(' and ')' also target square brackets
                              and curly braces when editing Clojure or Scheme.
 
@@ -413,6 +416,11 @@ to send the command line to the swank server for evaluation.
 
 Please find a video demonstration of the electric return feature here:
 http://img8.imageshack.us/img8/9479/openparen.gif
+
+                                                     *g:paredit_full_balancing*
+If nonzero, this option changes the default behavior of only balancing
+'(' and ')' when the language is Clojure or Scheme. Therefore, in this option
+'[', ']', '{', and '}' are also balanced regardless of the language.
 
                                                           *g:paredit_smartjump*
 If nonzero, this option changes the behavior of '(' and ')' in normal and visual

--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -29,6 +29,11 @@ if !exists( 'g:paredit_mode' )
     let g:paredit_mode = 1
 endif
 
+" Enable [] and {} balancing outside Clojure and Scheme
+if !exists( 'g:paredit_full_balancing' )
+    let g:paredit_full_balancing = 0
+endif
+
 " Match delimiter this number of lines before and after cursor position
 if !exists( 'g:paredit_matchlines' )
     let g:paredit_matchlines = 100
@@ -82,7 +87,7 @@ function! PareditInitBuffer()
     let b:paredit_init = 1
     " in case they are accidentally removed
     " Also define regular expressions to identify special characters used by paredit
-    if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+    if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
         let b:any_matched_char   = '(\|)\|\[\|\]\|{\|}\|\"'
         let b:any_matched_pair   = '()\|\[\]\|{}\|\"\"'
         let b:any_opening_char   = '(\|\[\|{'
@@ -219,7 +224,7 @@ function! PareditInitBuffer()
         silent! unmap  <buffer> cb
         silent! unmap  <buffer> ciw
         silent! unmap  <buffer> caw
-        if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+        if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
             silent! iunmap <buffer> [
             silent! iunmap <buffer> ]
             silent! iunmap <buffer> {
@@ -251,7 +256,7 @@ endfunction
 " Include all prefix and special characters in 'iskeyword'
 function! s:SetKeyword()
     let old_value = &iskeyword
-    if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+    if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
         setlocal iskeyword+=+,-,*,/,%,<,=,>,:,$,?,!,@-@,94,~,#,\|,&
     else
         setlocal iskeyword+=+,-,*,/,%,<,=,>,:,$,?,!,@-@,94,~,#,\|,&,.,{,},[,]
@@ -574,7 +579,7 @@ function! s:IsBalanced()
         return 0
     endif
 
-    if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+    if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
         let b1 = searchpair( '\[', '', '\]', 'brnmW', s:skip_sc, matchb )
         let b2 = searchpair( '\[', '', '\]',  'rnmW', s:skip_sc, matchf )
         if !(b1 == b2) && !(b1 == b2 - 1 && line[c-1] == '[') && !(b1 == b2 + 1 && line[c-1] == ']')
@@ -637,7 +642,7 @@ function! s:Unbalanced( matched )
     while 1
         let matched = tmp
         let tmp = substitute( tmp, '(\(\s*\))',   ' \1 ', 'g')
-        if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+        if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
             let tmp = substitute( tmp, '\[\(\s*\)\]', ' \1 ', 'g')
             let tmp = substitute( tmp, '{\(\s*\)}',   ' \1 ', 'g')
         endif
@@ -645,7 +650,7 @@ function! s:Unbalanced( matched )
         if tmp == matched
             " All paired chars eliminated
             let tmp = substitute( tmp, ')\(\s*\)(',   ' \1 ', 'g')
-            if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+            if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
                 let tmp = substitute( tmp, '\]\(\s*\)\[', ' \1 ', 'g')
                 let tmp = substitute( tmp, '}\(\s*\){',   ' \1 ', 'g')
             endif
@@ -810,7 +815,7 @@ function! s:ReGatherUp()
             normal! ddk
         endwhile
         normal! Jl
-    elseif g:paredit_electric_return && getline('.') =~ '^\s*\(\]\|}\)' && &ft =~ '.*\(clojure\|scheme\|racket\).*' 
+    elseif g:paredit_electric_return && getline('.') =~ '^\s*\(\]\|}\)' && (&ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing)
         " Re-gather electric returns in the current line for ']' and '}'
         normal! k
         while getline( line('.') ) =~ '^\s*$'
@@ -865,7 +870,7 @@ function! PareditInsertClosing( open, close )
             normal! Jl
             return
         endif
-        if len(nextline) > 0 && nextline[0] =~ '\]\|}' && &ft =~ '.*\(clojure\|scheme\|racket\).*' 
+        if len(nextline) > 0 && nextline[0] =~ '\]\|}' && (&ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing)
             " Re-gather electric returns in the line of the closing ']' or '}'
             call setline( line('.'), substitute( line, '\s*$', '', 'g' ) )
             normal! Jxl
@@ -1495,7 +1500,7 @@ function! s:FindClosing()
     endif
     call setpos( '.', [0, l, c, 0] )
 
-    if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+    if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
         call PareditFindClosing( '[', ']', 0 )
         let lp = line( '.' )
         let cp = col( '.' )

--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -155,7 +155,7 @@ function! PareditInitBuffer()
         execute 'nmap     <buffer> <silent> ' . g:paredit_leader.'<Up>    d[(,S'
         execute 'nmap     <buffer> <silent> ' . g:paredit_leader.'<Down>  d])%,S'
         call RepeatableNNoRemap(g:paredit_leader . 'I', ':<C-U>call PareditRaise()')
-        if &ft =~ '.*\(clojure\|scheme\|racket\).*'
+        if &ft =~ '.*\(clojure\|scheme\|racket\).*' || g:paredit_full_balancing
             inoremap <buffer> <expr>   [            PareditInsertOpening('[',']')
             inoremap <buffer> <silent> ]            <C-R>=(pumvisible() ? "\<lt>C-Y>" : "")<CR><C-O>:let save_ve=&ve<CR><C-O>:set ve=all<CR><C-O>:<C-U>call PareditInsertClosing('[',']')<CR><C-O>:let &ve=save_ve<CR>
             inoremap <buffer> <expr>   {            PareditInsertOpening('{','}')


### PR DESCRIPTION
I made this modification for myself, as having brackets automatically balanced is still a nice feature for other languages apart from Clojure and Scheme.
